### PR TITLE
Remove --use-system-libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.3-alpine
 
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
 RUN apk add --update build-base libxml2-dev libxslt-dev
-RUN gem install nokogiri -- --use-system-libraries
+RUN gem install nokogiri -- 
 RUN gem install html-proofer --no-ri --no-rdoc
 
 ENTRYPOINT ["htmlproofer"]


### PR DESCRIPTION
Building this Docker container was failing as --use-system-libraries is no more necessary since nokogiri 1.6.8.
Per [this GitHub discussion](https://github.com/gliderlabs/docker-alpine/issues/53)
