### PR TITLE
Slim down image size 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.3-alpine
 
+RUN echo 'gem: --no-document' >> /etc/gemrc
+
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
 RUN apk add --update build-base libxml2-dev libxslt-dev
 RUN gem install nokogiri -- --use-system-libraries

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ruby:2.3-alpine
 
 RUN echo 'gem: --no-document' >> /etc/gemrc
 
+RUN apk add --no-cache \
+  libcurl
+
 RUN apk add --no-cache --virtual build-dependencies \
   build-base \
   libxml2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,12 @@ FROM ruby:2.3-alpine
 
 RUN echo 'gem: --no-document' >> /etc/gemrc
 
-# https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
-RUN apk add --no-cache \
+RUN apk add --no-cache --virtual build-dependencies \
   build-base \
   libxml2-dev \
-  libxslt-dev
-
-RUN gem install html-proofer
+  libxslt-dev \
+  && gem install html-proofer \
+  && apk del build-dependencies
 
 ENTRYPOINT ["htmlproofer"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM ruby:2.3-alpine
 RUN echo 'gem: --no-document' >> /etc/gemrc
 
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
-RUN apk add --update build-base libxml2-dev libxslt-dev
+RUN apk add --no-cache \
+  build-base \
+  libxml2-dev \
+  libxslt-dev
 
 RUN gem install html-proofer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN echo 'gem: --no-document' >> /etc/gemrc
 
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
 RUN apk add --update build-base libxml2-dev libxslt-dev
-RUN gem install nokogiri -- --use-system-libraries
-RUN gem install html-proofer --no-ri --no-rdoc
+
+RUN gem install html-proofer
 
 ENTRYPOINT ["htmlproofer"]
 CMD ["--help"]


### PR DESCRIPTION
Based on https://github.com/18F/html-proofer-docker/pull/3.
Merge this one first, then review this one.

It uses Virtual Packages.

This reduces for me the container size by 42%.