### PR TITLE
Added GitLab CI tag and updated Ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.4-alpine
 
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
 RUN apk add --update build-base libxml2-dev libxslt-dev libcurl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.3-alpine
 
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
-RUN apk add --update build-base libxml2-dev libxslt-dev
+RUN apk add --update build-base libxml2-dev libxslt-dev libcurl
 RUN gem install nokogiri -- --use-system-libraries
 RUN gem install html-proofer --no-ri --no-rdoc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.3-alpine
+
+# https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
+RUN apk add --update build-base libxml2-dev libxslt-dev
+RUN gem install nokogiri -- --use-system-libraries
+RUN gem install html-proofer --no-ri --no-rdoc
+
+ENTRYPOINT ["htmlproofer"]
+CMD ["--help"]

--- a/Dockerfile-gitlabci
+++ b/Dockerfile-gitlabci
@@ -1,6 +1,6 @@
 FROM ruby:2.3-alpine
 
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
-RUN apk add --update build-base libxml2-dev libxslt-dev
+RUN apk add --update build-base libxml2-dev libxslt-dev libcurl
 RUN gem install nokogiri -- --use-system-libraries
 RUN gem install html-proofer --no-ri --no-rdoc

--- a/Dockerfile-gitlabci
+++ b/Dockerfile-gitlabci
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.4-alpine
 
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
 RUN apk add --update build-base libxml2-dev libxslt-dev libcurl

--- a/Dockerfile-gitlabci
+++ b/Dockerfile-gitlabci
@@ -4,6 +4,3 @@ FROM ruby:2.3-alpine
 RUN apk add --update build-base libxml2-dev libxslt-dev
 RUN gem install nokogiri -- --use-system-libraries
 RUN gem install html-proofer --no-ri --no-rdoc
-
-ENTRYPOINT ["htmlproofer"]
-CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ e.g. those created by a static site builder like [Jekyll](http://jekyllrb.com/) 
 ```bash
 docker run -v /absolute/path/to/dir/:/site 18fgsa/html-proofer /site
 ```
+
+### GitLab CI
+
+You can use this image in GitLab CI, just configure job in `.gitlab-ci.yml` like this:
+
+```yaml
+test:
+  image: 18fgsa/html-proofer:gitlabci
+  script:
+    - htmlproofer _site --empty-alt-ignore
+```


### PR DESCRIPTION
- added Dockerfile variant fro GitLab CI because it does not like images with non-shell ENTRYPOINT
- updated Ruby
- added libcurl because if is missing in Alpine now and HTML proofer requires it

I've [published this fork on Docker Hub](https://hub.docker.com/r/bobik/html-proofer-docker/) and already using it in GitLab CI. When this PR will be accepted I will delete it.

You should also configure [your Docker Hub](https://hub.docker.com/r/18fgsa/html-proofer/) project:
- [ ] In Build Settings add tag named "gitlabci" with Dockerfile location "/Dockerfile-gitlabci"
- [x] Add Repository link to "ruby"